### PR TITLE
fix npm publish to include dist files by flattening ./dist, clean on …

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,4 +3,4 @@ npm-debug.log
 .vscode
 
 tests
-src
+/src

--- a/example-code/es6-example.js
+++ b/example-code/es6-example.js
@@ -1,5 +1,5 @@
 "use strict";
-const toxiproxyClient = require("../dist/src");
+const toxiproxyClient = require("../dist/");
 
 const getToxic = (type, attributes) => {
   return new Promise((resolve, reject) => {

--- a/example-code/typescript-example.ts
+++ b/example-code/typescript-example.ts
@@ -2,7 +2,7 @@ import {
     Toxiproxy,
     ICreateProxyBody,
     Toxic, ICreateToxicBody, Bandwidth
-} from "../src";
+} from "../dist/";
 
 const getToxic = async <T>(type: string, attributes: T): Promise<Toxic<T>> => {
   const toxiproxy = new Toxiproxy("http://localhost:8474");

--- a/package.json
+++ b/package.json
@@ -2,12 +2,14 @@
   "name": "toxiproxy-node-client",
   "version": "v2.0.5",
   "description": "Node Client for Toxiproxy",
-  "main": "./dist/src/index.js",
-  "typings": "./dist/src/index.d.ts",
+  "main": "./dist/index.js",
+  "typings": "./dist/index.d.ts",
   "scripts": {
-    "test": "ava -v -s ./dist/tests/*.js ./dist/tests/**/*.js",
-    "lint": "tslint ./tests/**/*.ts ./src/**/*.ts && echo linted",
-    "build": "tsc --noUnusedParameters --noUnusedLocals --strictNullChecks && echo built"
+    "clean": "del ./dist",
+    "test": "npm run build && ava -v -s ./dist/tests/**/*.js",
+    "lint": "tslint ./src/**/*.ts && echo linted",
+    "build": "npm run clean && tsc && echo built",
+    "prepublish": "npm run build"
   },
   "repository": {
     "type": "git",
@@ -23,6 +25,7 @@
     "@types/http-status": "^0.2.29",
     "@types/request-promise-native": "^1.0.2",
     "ava": "^0.17.0",
+    "del-cli": "^0.2.1",
     "tslint": "^4.2.0",
     "typescript": "^2.1.4"
   },

--- a/src/tests/Proxy.ts
+++ b/src/tests/Proxy.ts
@@ -1,6 +1,6 @@
 import { test } from "ava";
-import { createProxy, createToxic } from "../src/TestHelper";
-import { Latency } from "../src/Toxic";
+import { createProxy, createToxic } from "../TestHelper";
+import { Latency } from "../Toxic";
 
 test("Proxy Should update a proxy", async (t) => {
   const { proxy } = await createProxy(t, "update-proxy-test");

--- a/src/tests/Toxic.ts
+++ b/src/tests/Toxic.ts
@@ -1,6 +1,6 @@
 import { test } from "ava";
-import { createProxy, createToxic } from "../src/TestHelper";
-import { Latency } from "../src/Toxic";
+import { createProxy, createToxic } from "../TestHelper";
+import { Latency } from "../Toxic";
 
 test("Toxic Should remove a toxic", async (t) => {
   const { proxy } = await createProxy(t, "remove-toxic-test");

--- a/src/tests/ToxicTypes.ts
+++ b/src/tests/ToxicTypes.ts
@@ -1,9 +1,9 @@
 import { test } from "ava";
-import { createProxy, createToxic } from "../src/TestHelper";
+import { createProxy, createToxic } from "../TestHelper";
 import {
   Latency, Bandwidth,
   Slowclose, Timeout, Slicer
-} from "../src/Toxic";
+} from "../Toxic";
 
 test("Proxy Should add a latency toxic", async (t) => {
   const { proxy } = await createProxy(t, "add-latency-toxic-test");

--- a/src/tests/Toxiproxy.ts
+++ b/src/tests/Toxiproxy.ts
@@ -1,7 +1,7 @@
 import { test } from "ava";
-import { createProxy, toxiproxyUrl } from "../src/TestHelper";
-import Toxiproxy from "../src/Toxiproxy";
-import { ICreateProxyBody } from "../src/interfaces";
+import { createProxy, toxiproxyUrl } from "../TestHelper";
+import Toxiproxy from "../Toxiproxy";
+import { ICreateProxyBody } from "../interfaces";
 
 test("Toxiproxy Should create a proxy", async (t) => {
   const { proxy } = await createProxy(t, "create-test");

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,13 +3,20 @@
         "module": "commonjs",
         "target": "es6",
         "noImplicitAny": false,
+        "noUnusedParameters": true,
+        "noUnusedLocals": true,
+        "strictNullChecks": true,
         "sourceMap": false,
         "removeComments": true,
         "declaration": true,
+        "rootDir": "./src",
         "outDir": "./dist"
     },
     "filesGlob": [
-        "**/*.ts",
-        "!node_modules/**"
+        "./src/**/*.ts"
+    ],
+    "exclude": [
+        "./example-code",
+        "./node_modules"
     ]
 }


### PR DESCRIPTION
Thanks for releasing this. Here is a quick PR to fix the npm release from ignoring dist/src/*.

This PR:
1. Flattens ./dist to match ./src
2. Explicitly ignores ./src
3. Cleans ./dist on build/test
4. Moves all configuration options to tsconfig.json
5. Examples should both use compiled code