### PR TITLE
Refactoring ES6 examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,25 +18,21 @@ Here is an example for creating a proxy that limits a Redis connection to 1000KB
 const toxiproxyClient = require("toxiproxy-node-client");
 
 const getToxic = (type, attributes) => {
-  return new Promise((resolve, reject) => {
-    const toxiproxy = new toxiproxyClient.Toxiproxy("http://localhost:8474");
-    const proxyBody = {
-      listen: "localhost:0",
-      name: "ihsw_test_redis_master",
-      upstream: "localhost:6379"
-    };
-    toxiproxy.createProxy(proxyBody)
-      .then((proxy) => {
-        const toxicBody = {
-          attributes: attributes,
-          type: type
-        };
-        return proxy.addToxic(new toxiproxyClient.Toxic(proxy, toxicBody));
-      })
-      .then(resolve)
-      .catch(reject);
+  const toxiproxy = new toxiproxyClient.Toxiproxy("http://localhost:8474");
+  const proxyBody = {
+    listen: "localhost:0",
+    name: "ihsw_test_redis_master",
+    upstream: "localhost:6379"
+  };
+  return toxiproxy.createProxy(proxyBody)
+    .then((proxy) => {
+      const toxicBody = {
+        attributes: attributes,
+        type: type
+      };
+      return proxy.addToxic(new toxiproxyClient.Toxic(proxy, toxicBody));
+    });
   });
-};
 
 // { attributes: { rate: 1000 },
 //   name: 'bandwidth_downstream',

--- a/example-code/es6-example.js
+++ b/example-code/es6-example.js
@@ -2,24 +2,20 @@
 const toxiproxyClient = require("../dist/");
 
 const getToxic = (type, attributes) => {
-  return new Promise((resolve, reject) => {
-    const toxiproxy = new toxiproxyClient.Toxiproxy("http://localhost:8474");
-    const proxyBody = {
-      listen: "localhost:0",
-      name: "ihsw_test_redis_master",
-      upstream: "localhost:6379"
-    };
-    toxiproxy.createProxy(proxyBody)
-      .then((proxy) => {
-        const toxicBody = {
-          attributes: attributes,
-          type: type
-        };
-        return proxy.addToxic(new toxiproxyClient.Toxic(proxy, toxicBody));
-      })
-      .then(resolve)
-      .catch(reject);
-  });
+  const toxiproxy = new toxiproxyClient.Toxiproxy("http://localhost:8474");
+  const proxyBody = {
+    listen: "localhost:0",
+    name: "ihsw_test_redis_master",
+    upstream: "localhost:6379"
+  };
+  return toxiproxy.createProxy(proxyBody)
+    .then((proxy) => {
+      const toxicBody = {
+        attributes: attributes,
+        type: type
+      };
+      return proxy.addToxic(new toxiproxyClient.Toxic(proxy, toxicBody));
+    });
 };
 
 // { attributes: { rate: 1000 },


### PR DESCRIPTION
**Description:** Simplified the examples a bit and removed the wrapping promise to use the promise returned by `toxiproxy.createProxy`

cc @ihsw @chrisblossom 