### PR TITLE
feat(api): make `Proxy` and `Toxic` classes immutable 

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,32 +16,20 @@ Here is an example for creating a proxy that limits a Redis connection to 1000KB
 // index.js
 "use strict";
 const toxiproxyClient = require("toxiproxy-node-client");
-
-const getToxic = (type, attributes) => {
-  const toxiproxy = new toxiproxyClient.Toxiproxy("http://localhost:8474");
-  const proxyBody = {
-    listen: "localhost:0",
-    name: "ihsw_test_redis_master",
-    upstream: "localhost:6379"
-  };
-  return toxiproxy.createProxy(proxyBody)
-    .then((proxy) => {
-      const toxicBody = {
-        attributes: attributes,
-        type: type
-      };
-      return proxy.addToxic(new toxiproxyClient.Toxic(proxy, toxicBody));
-    });
+const toxiproxy = new toxiproxyClient.Toxiproxy("http://localhost:8474");
+const proxyBody = {
+  listen: "localhost:0",
+  name: "redis",
+  upstream: "redis:6379"
+};
+const toxic = toxiproxy.createProxy(proxyBody)
+  .then((proxy) => {
+    const toxicBody = {
+      attributes: { rate: 1000 },
+      type: "bandwidth"
+    };
+    return proxy.addToxic(toxicBody);
   });
-
-// { attributes: { rate: 1000 },
-//   name: 'bandwidth_downstream',
-//   stream: 'downstream',
-//   toxicity: 1,
-//   type: 'bandwidth' }
-getToxic("bandwidth", { rate: 1000 })
-  .then((toxic) => console.log(toxic.toJson()))
-  .catch(console.error);
 ```
 
 ## TypeScript Usage
@@ -55,30 +43,19 @@ import {
     Toxic, ICreateToxicBody, Bandwidth
 } from "toxiproxy-node-client";
 
-const getToxic = async <T>(type: string, attributes: T): Promise<Toxic<T>> => {
-  const toxiproxy = new Toxiproxy("http://localhost:8474");
-  const proxyBody = <ICreateProxyBody>{
-    listen: "localhost:0",
-    name: "ihsw_test_redis_master",
-    upstream: "localhost:6379"
-  };
-  const proxy = await toxiproxy.createProxy(proxyBody);
-
-  const toxicBody = <ICreateToxicBody<T>>{
-      attributes: attributes,
-      type: type
-  };
-  return await proxy.addToxic(new Toxic(proxy, toxicBody));
+const toxiproxy = new Toxiproxy("http://localhost:8474");
+const proxyBody = {
+  listen: "localhost:0",
+  name: "redis",
+  upstream: "redis:6379"
 };
+const proxy = await toxiproxy.createProxy(proxyBody);
 
-// { attributes: { rate: 1000 },
-//   name: 'bandwidth_downstream',
-//   stream: 'downstream',
-//   toxicity: 1,
-//   type: 'bandwidth' }
-getToxic("bandwidth", <Bandwidth>{ rate: 1000 })
-  .then((toxic) => console.log(toxic.toJson()))
-  .catch(console.error);
+const toxicBody = <ICreateToxicBody<T>>{
+  attributes: <Bandwidth>{ rate: 1000 },
+  type: "bandwidth"
+};
+const toxic = proxy.addToxic(toxicBody);
 ```
 
 ## Documentation

--- a/example-code/es6-example.js
+++ b/example-code/es6-example.js
@@ -14,7 +14,7 @@ const getToxic = (type, attributes) => {
         attributes: attributes,
         type: type
       };
-      return proxy.addToxic(new toxiproxyClient.Toxic(proxy, toxicBody));
+      return proxy.addToxic(toxicBody);
     });
 };
 

--- a/example-code/typescript-example.ts
+++ b/example-code/typescript-example.ts
@@ -15,7 +15,7 @@ const getToxic = async <T>(type: string, attributes: T): Promise<Toxic<T>> => {
         attributes: attributes,
         type: type
     };
-    return await proxy.addToxic(new Toxic(proxy, toxicBody));
+    return await proxy.addToxic(toxicBody);
 };
 
 // { attributes: { rate: 1000 },

--- a/src/Proxy.ts
+++ b/src/Proxy.ts
@@ -1,7 +1,5 @@
-import axios from "axios";
 import Toxiproxy from "./Toxiproxy";
 import Toxic, {
-    AttributeTypes as ToxicAttributeTypes,
     ToxicJson
 } from "./Toxic";
 import {
@@ -9,8 +7,9 @@ import {
     IGetProxyResponse,
     IUpdateProxyBody, IUpdateProxyResponse,
     ICreateToxicBody, ICreateToxicResponse,
-    IGetToxicsResponse
+    IGetToxicResponse
 } from "./interfaces";
+import { AxiosInstance } from "axios";
 
 export interface ProxyJson {
     name: string;
@@ -21,24 +20,27 @@ export interface ProxyJson {
 }
 
 export default class Proxy {
-    toxiproxy: Toxiproxy;
+    readonly toxiproxy: Toxiproxy;
+    readonly api: AxiosInstance;
 
-    name: string;
-    listen: string;
-    upstream: string;
-    enabled: boolean;
-    toxics: Toxic<ToxicAttributeTypes>[];
+    readonly name: string;
+    readonly listen: string;
+    readonly upstream: string;
+    readonly enabled: boolean;
 
     constructor(toxiproxy: Toxiproxy, body: ICreateProxyResponse | IGetProxyResponse) {
-        this.toxics = [];
+        this.api = toxiproxy.api;
         this.toxiproxy = toxiproxy;
 
-        const { name, listen, upstream, enabled, toxics } = body;
+        const { name, listen, upstream, enabled } = body;
         this.name = name;
         this.listen = listen;
         this.upstream = upstream;
         this.enabled = enabled;
-        this.setToxics(toxics);
+    }
+
+    getToxiproxy(): Toxiproxy {
+        return this.toxiproxy;
     }
 
     toJson(): ProxyJson {
@@ -46,13 +48,8 @@ export default class Proxy {
             enabled: this.enabled,
             listen: this.listen,
             name: this.name,
-            toxics: this.toxics.map((toxic) => toxic.toJson()),
             upstream: this.upstream
         };
-    }
-
-    setToxics(toxics: IGetToxicsResponse<any>) {
-        this.toxics = toxics.map((v: any) => new Toxic<ToxicAttributeTypes>(this, v));
     }
 
     getHost() {
@@ -63,31 +60,50 @@ export default class Proxy {
         return `${this.getHost()}/proxies/${this.name}`;
     }
 
+    /**
+     * Deletes the proxy from the server.
+     */
     async remove(): Promise<void> {
-        await axios.delete(this.getPath());
+        await this.api.delete(this.getPath());
     }
 
-    async update(): Promise<Proxy> {
-        const body = <IUpdateProxyBody>{
-            enabled: this.enabled,
-            listen: this.listen,
-            upstream: this.upstream
-        };
-
-        const res = await axios.post<IUpdateProxyResponse>(this.getPath(), body);
-        return new Proxy(this.toxiproxy, res.data);
+    /**
+     * Updates the existing proxy on the server (e.g. disable an enabled proxy).
+     *
+     * @returns updated proxy
+     */
+    async update(body: IUpdateProxyBody): Promise<Proxy> {
+        return await this.api.post<IUpdateProxyResponse>(this.getPath(), body)
+            .then((response) => {
+                return new Proxy(this.toxiproxy, response.data);
+            });
     }
 
-    async refreshToxics(): Promise<void> {
-        const res = await axios.get<IGetToxicsResponse<any>>(`${this.getPath()}/toxics`);
-        this.setToxics(res.data);
-    }
-
+    /**
+     * Adds a new toxic to the proxy.
+     *
+     * @param body toxic attributes
+     * @returns toxic
+     */
     async addToxic<T>(body: ICreateToxicBody<T>): Promise<Toxic<T>> {
-        const response = await axios.post<ICreateToxicResponse<T>>(`${this.getPath()}/toxics`, body);
-        const toxic = new Toxic<T>(this, response.data);
+        const result = await this.api.post<ICreateToxicResponse<T>>(`${this.getPath()}/toxics`, body)
+            .then((response) => {
+                return response.data;
+            });
+        return new Toxic<T>(this.api, this.getPath(), result);
+    }
 
-        this.toxics.push(toxic as Toxic<ToxicAttributeTypes>);
-        return toxic;
+    /**
+     * Gets the toxic from the proxy.
+     *
+     * @param name toxic name
+     * @returns toxic
+     */
+    async getToxic<T>(name: string): Promise<Toxic<T>> {
+        const result = await this.api.get<IGetToxicResponse<T>>(`${this.getPath()}/toxics/${name}`)
+            .then((response) => {
+                return response.data;
+            });
+        return new Toxic<T>(this.api, this.getPath(), result);
     }
 }

--- a/src/TestHelper.ts
+++ b/src/TestHelper.ts
@@ -2,7 +2,6 @@ import Toxiproxy from "./Toxiproxy";
 import Proxy from "./Proxy";
 import Toxic from "./Toxic";
 import { ICreateProxyBody, ICreateToxicBody } from "./interfaces";
-import {expect} from "@jest/globals";
 
 export interface ICreateProxyHelper {
     proxy: Proxy;
@@ -19,8 +18,6 @@ export const createProxy = async (name: string): Promise<ICreateProxyHelper> => 
         upstream: "localhost:6379"
     };
     const proxy = await toxiproxy.createProxy(body);
-    expect(body.name).toBe(proxy.name);
-
     return { proxy, toxiproxy };
 };
 
@@ -30,11 +27,7 @@ export const createToxic = async <T>(proxy: Proxy, type: string, attributes: T):
         type: type
     };
 
-    const toxic = await proxy.addToxic(body);
-    expect(body.type).toBe(toxic.type);
-    expect(toxic.name).toBe(proxy.toxics[proxy.toxics.length - 1].name);
-
-    return toxic;
+    return await proxy.addToxic(body);
 };
 
 export async function removeAllProxies() {

--- a/src/Toxiproxy.ts
+++ b/src/Toxiproxy.ts
@@ -1,4 +1,4 @@
-import axios from "axios";
+import axios, { AxiosError, AxiosInstance } from "axios";
 
 import Proxy from "./Proxy";
 import {
@@ -14,19 +14,50 @@ export interface Proxies {
     [name: string]: Proxy;
 }
 
+export class ToxiproxyError {
+    name: string;
+    message: string;
+    stack?: string;
+
+    constructor(name: string, message: string, stack?: string) {
+        this.name = name;
+        this.message = message;
+        this.stack = stack;
+    }
+}
+
 export default class Toxiproxy {
     host: string;
+    api: AxiosInstance;
+
     constructor(host: string) {
+        this.api = axios.create();
+        this.api.interceptors.response.use((response) => response, (error) => {  
+            if (error instanceof AxiosError) {
+                // Return a simplified error object to avoid "TypeError: Converting circular structure to JSON".
+                // Really not sure why this is not the default behavior.
+                return Promise.reject(new ToxiproxyError(
+                    error.name,
+                    error.message,
+                    error.stack,
+                ));
+            }
+            return Promise.reject("Unknown error");
+        });
         this.host = host;
     }
 
+    getApi(): AxiosInstance {
+        return this.api;
+    }
+
     async createProxy(body: ICreateProxyBody): Promise<Proxy> {
-        const result = await axios.post<ICreateProxyResponse>(`${this.host}/proxies`, body);
+        const result = await this.api.post<ICreateProxyResponse>(`${this.host}/proxies`, body);
         return new Proxy(this, result.data);
     }
 
     async populate(body: IPopulateProxiesBody): Promise<Proxies> {
-        const res = await axios.post<IPopulateProxiesResponse>(`${this.host}/populate`, body);
+        const res = await this.api.post<IPopulateProxiesResponse>(`${this.host}/populate`, body);
 
         const proxies: Proxies = {};
         for (const proxyResponse of res.data.proxies) {
@@ -37,20 +68,20 @@ export default class Toxiproxy {
     }
 
     async get(name: string): Promise<Proxy> {
-        const result = await axios.get<IGetProxyResponse>(`${this.host}/proxies/${name}`);
+        const result = await this.api.get<IGetProxyResponse>(`${this.host}/proxies/${name}`);
         return new Proxy(this, result.data);
     }
 
     async getVersion(): Promise<string> {
-        return await axios.get(`${this.host}/version`);
+        return await this.api.get(`${this.host}/version`);
     }
 
     async reset(): Promise<void> {
-        return await axios.post(`${this.host}/reset`);
+        return await this.api.post(`${this.host}/reset`);
     }
 
     async getAll(): Promise<Proxies> {
-        const responses = await axios.get<IGetProxiesResponse>(`${this.host}/proxies`);
+        const responses = await this.api.get<IGetProxiesResponse>(`${this.host}/proxies`);
 
         const proxies: Proxies = {
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -143,12 +143,3 @@ export interface IGetToxicResponse<T> extends IToxicResponse<T> { }
 // request & responses for POST /proxies/{proxy}/toxics/{toxic}
 export interface IUpdateToxicBody<T> extends IToxicBody<T> { }
 export interface IUpdateToxicResponse<T> extends IToxicResponse<T> { }
-
-// request & responses for DELETE /proxies/{proxy}/toxics/{toxic}
-// intentionally left blank
-
-// request & responses for POST /reset
-// intentionally left blank
-
-// request & responses for GET /version
-// intentionally left blank

--- a/src/tests/Proxy.spec.ts
+++ b/src/tests/Proxy.spec.ts
@@ -1,6 +1,6 @@
-import {createProxy, createToxic, removeAllProxies} from "../TestHelper";
-import { Latency } from "../Toxic";
-import { expect, test} from "@jest/globals";
+import { createProxy, removeAllProxies } from "../TestHelper";
+import { expect, test } from "@jest/globals";
+import { IUpdateProxyBody } from "../interfaces";
 
 beforeAll(async () => {
     await removeAllProxies();
@@ -9,9 +9,22 @@ beforeAll(async () => {
 test("Proxy Should update a proxy", async () => {
     const { proxy } = await createProxy("update-proxy-test");
 
-    proxy.enabled = false;
-    const updatedProxy = await proxy.update();
-    expect(proxy.enabled).toBe(updatedProxy.enabled);
+    const disable = <IUpdateProxyBody>{
+        enabled: false,
+        listen: proxy.listen,
+        upstream: proxy.upstream
+    };
+    const disabledProxy = await proxy.update(disable);
+    expect(disabledProxy.enabled).toBeFalsy();
+
+    const updateUpstream = <IUpdateProxyBody>{
+        enabled: true,
+        listen: proxy.listen,
+        upstream: "somehost:12345"
+    };
+    const updatedUpstreamProxy = await proxy.update(updateUpstream);
+    expect(updatedUpstreamProxy.enabled).toBeTruthy();
+    expect(updatedUpstreamProxy.upstream).toBe(updateUpstream.upstream);
 
     return proxy.remove();
 });
@@ -22,20 +35,10 @@ test("Proxy Should remove a proxy", async () => {
     return proxy.remove();
 });
 
-test("Proxy Should refresh toxics", async () => {
-    const { proxy } = await createProxy("remove-test");
-
-    const attributes = <Latency>{ latency: 1000, jitter: 100 };
-    const toxic = await createToxic(proxy, "latency", attributes);
-    await proxy.refreshToxics();
-    const hasToxic = proxy.toxics.reduce((hasToxic, proxyToxic) => {
-        if (proxyToxic.name === toxic.name) {
-            return true;
-        }
-
-        return hasToxic;
-    }, false);
-    expect(hasToxic).toBe(true);
-
+test("Creating the same proxy twice should result in an error", async () => {
+    const { proxy } = await createProxy("duplicate");
+    await createProxy("duplicate").catch((error) => {
+        expect(error.message).toBe("Request failed with status code 409");
+    });
     return proxy.remove();
 });


### PR DESCRIPTION
Make `Proxy` and `Toxic` classes immutable  and remove cyclic dependencies.

Removing the cyclic dependencies between the objects has many benefits, for example JSON (de-)serialization of Axios errors now just works.

BREAKING CHANGE: `Proxy` and `Toxic` objects are now updated by posting an update to the server with the attributes to be updated. This is a breaking change because the `update` methods return a new instance of a `Proxy` or `Toxic` object instead of returning the mutated object.